### PR TITLE
Publish some methods

### DIFF
--- a/Sources/Dispatch.swift
+++ b/Sources/Dispatch.swift
@@ -148,7 +148,7 @@ public struct Dispatch {
 
 //MARK: Chainable methods
 
-extension Dispatch {
+public extension Dispatch {
   
   //MARK: Static methods
   
@@ -215,7 +215,7 @@ extension Dispatch {
 
 //MARK: Non-Chainable Methods
 
-extension Dispatch {
+public extension Dispatch {
   
   static func once(inout token: dispatch_once_t, closure: DispatchClosure) {
     dispatch_once(&token, closure)


### PR DESCRIPTION
When use `Dispatch` on DynamicFramework(CocoaPods or Carthage), cann't use some methods.

ex.

```
import DispatchFramework

let someCustomQueue = dispatch_queue_create("custom.queue.dispatch", DISPATCH_QUEUE_CONCURRENT)
Dispatch.sync(someCustomQueue) {} // Cann't called
```

Added the public keyword in order to use.
